### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "license": "MIT",
   "scripts": {
-    "start": "./node_modules/.bin/parcel src/index.html"
+    "start": "parcel src/index.html"
   },
   "dependencies": {
     "react": "^16.2.0",


### PR DESCRIPTION
path to specific parcel bin is unnecessary because npm and yarn will search in that .bin for an executable first.